### PR TITLE
chore: bump cm-pgn to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chess.mjs": "^1.4.0",
-        "cm-pgn": "3.3.2"
+        "cm-pgn": "^4.0.6"
       },
       "devDependencies": {
         "teevi": "^2.2.4"
@@ -22,12 +22,19 @@
       "integrity": "sha512-TxbpfE4BvRMteIWEy9j1wsR/UwYqGekmZFDcPrKjaqHbmeRwQOv5sribu6PE6nO/69uTxld0nfX7Ra0XA03j4Q=="
     },
     "node_modules/cm-pgn": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/cm-pgn/-/cm-pgn-3.3.2.tgz",
-      "integrity": "sha512-oTL4cWJy8rmy7jXwoji2dcnLIzB2MfnzRML6INw2j8oSLs/UBqIPNnrXCZo49ZHhrGoqix//yOWwL+x44owznA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/cm-pgn/-/cm-pgn-4.0.6.tgz",
+      "integrity": "sha512-4nsWoI+vEGrLaGM2vSOng00qvIl3Oj4bx+5UfFdH8MT7DiaphVt+7vo8PuzUV+jJhmvYnV83/UNv4gyr03Rlfw==",
+      "license": "MIT",
       "dependencies": {
-        "chess.mjs": "^1.4.0"
+        "chess.mjs": "^2.2.3"
       }
+    },
+    "node_modules/cm-pgn/node_modules/chess.mjs": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/chess.mjs/-/chess.mjs-2.2.6.tgz",
+      "integrity": "sha512-kteiZrVz42EsEJjb2G8NlCZg4fNPlSBAnIbywK065TVtnEvRqyHTN+OVR+vZ/A1iGNM/6kZpbiyUpisCwq8oUg==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/teevi": {
       "version": "2.2.4",
@@ -43,11 +50,18 @@
       "integrity": "sha512-TxbpfE4BvRMteIWEy9j1wsR/UwYqGekmZFDcPrKjaqHbmeRwQOv5sribu6PE6nO/69uTxld0nfX7Ra0XA03j4Q=="
     },
     "cm-pgn": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/cm-pgn/-/cm-pgn-3.3.2.tgz",
-      "integrity": "sha512-oTL4cWJy8rmy7jXwoji2dcnLIzB2MfnzRML6INw2j8oSLs/UBqIPNnrXCZo49ZHhrGoqix//yOWwL+x44owznA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/cm-pgn/-/cm-pgn-4.0.6.tgz",
+      "integrity": "sha512-4nsWoI+vEGrLaGM2vSOng00qvIl3Oj4bx+5UfFdH8MT7DiaphVt+7vo8PuzUV+jJhmvYnV83/UNv4gyr03Rlfw==",
       "requires": {
-        "chess.mjs": "^1.4.0"
+        "chess.mjs": "^2.2.3"
+      },
+      "dependencies": {
+        "chess.mjs": {
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/chess.mjs/-/chess.mjs-2.2.6.tgz",
+          "integrity": "sha512-kteiZrVz42EsEJjb2G8NlCZg4fNPlSBAnIbywK065TVtnEvRqyHTN+OVR+vZ/A1iGNM/6kZpbiyUpisCwq8oUg=="
+        }
       }
     },
     "teevi": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/shaack/cm-chess#readme",
   "dependencies": {
     "chess.mjs": "^1.4.0",
-    "cm-pgn": "3.3.2"
+    "cm-pgn": "^4.0.6"
   },
   "devDependencies": {
     "teevi": "^2.2.4"


### PR DESCRIPTION
Upgrades `cm-pgn` to latest version to fix bugs with variations. 

Currently: Same line is stored as new variation because of a bug in old `cm-pgn` version
Fix: upgrading to latest `cm-pgn` fixes this for `cm-chess`